### PR TITLE
Adds basic windows title functionality

### DIFF
--- a/src/logstalgia.cpp
+++ b/src/logstalgia.cpp
@@ -530,7 +530,7 @@ void Logstalgia::changeSummarizerAbbreviationDepth(Summarizer* summarizer, int d
     int depth = summarizer->getAbbreviationDepth();
     int new_depth = depth + delta;
 
-    if(new_depth >= -1) {        
+    if(new_depth >= -1) {
         std::string title = (summarizer == ipSummarizer) ? "IP Summarizer" : summarizer->getTitle().c_str();
         debugLog("%s min abbreviation depth changed to %d", title.c_str(), new_depth);
         summarizer->setAbbreviationDepth(new_depth);
@@ -1809,6 +1809,12 @@ void Logstalgia::draw(float t, float dt) {
     } else {
         fontMedium.draw(2,2,  displaydate.c_str());
         fontMedium.draw(2,19, displaytime.c_str());
+    }
+
+    if (settings.windows_title.length() > 0) {
+        int titlew = fontMedium.getWidth(settings.windows_title);
+        int titlex = (display.width / 2) - (titlew / 2);
+        fontMedium.print(titlex, 2, "%s", settings.windows_title.c_str());
     }
 
     fontLarge.setColour(vec4(1.0f,1.0f,1.0f,font_alpha));

--- a/src/logstalgia.cpp
+++ b/src/logstalgia.cpp
@@ -1811,10 +1811,10 @@ void Logstalgia::draw(float t, float dt) {
         fontMedium.draw(2,19, displaytime.c_str());
     }
 
-    if (settings.windows_title.length() > 0) {
-        int titlew = fontMedium.getWidth(settings.windows_title);
+    if(settings.title.length() > 0) {
+        int titlew = fontMedium.getWidth(settings.title);
         int titlex = (display.width / 2) - (titlew / 2);
-        fontMedium.print(titlex, 2, "%s", settings.windows_title.c_str());
+        fontMedium.print(titlex, 2, "%s", settings.title.c_str());
     }
 
     fontLarge.setColour(vec4(1.0f,1.0f,1.0f,font_alpha));

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -104,7 +104,7 @@ void LogstalgiaSettings::help(bool extended_help) {
     printf("  -o, --output-ppm-stream FILE   Write frames as PPM to a file ('-' for STDOUT)\n");
     printf("  -r, --output-framerate  FPS    Framerate of output (25,30,60)\n\n");
 
-    printf("  --windows-title TITLE      Title for Logstalgia window (default: empty)\n\n");
+    printf("  --title TITLE              Set a title\n\n");
 
     printf("FILE should be a log file or '-' to read STDIN.\n\n");
 
@@ -206,7 +206,7 @@ LogstalgiaSettings::LogstalgiaSettings() {
     arg_types["address-separators"] = "string";
     arg_types["group-separators"]   = "string";
 
-    arg_types["windows-title"]   = "string";
+    arg_types["title"] = "string";
 }
 
 void LogstalgiaSettings::setLogstalgiaDefaults() {
@@ -262,7 +262,7 @@ void LogstalgiaSettings::setLogstalgiaDefaults() {
 
     font_size = 14;
 
-    windows_title = "";
+    title = "";
 
     groups.clear();
 }
@@ -700,15 +700,11 @@ void LogstalgiaSettings::importLogstalgiaSettings(ConfFile& conffile, ConfSectio
         std::cin.clear();
     }
 
-    if((entry = settings->getEntry("windows-title")) != 0) {
+    if((entry = settings->getEntry("title")) != 0) {
 
-        if(!entry->hasValue()) conffile.entryException(entry, "specify windows title");
+        if(!entry->hasValue()) conffile.entryException(entry, "specify title");
 
-        windows_title = entry->getString();
-
-        if(windows_title.empty() || windows_title.size() > 100) {
-            conffile.invalidValueException(entry);
-        }
+        title = entry->getString();
     }
 
 }
@@ -870,8 +866,8 @@ void LogstalgiaSettings::exportLogstalgiaSettings(ConfFile& conf) {
 
     settings->addEntry("path", path);
 
-    if (windows_title.length() > 0) {
-        settings->addEntry(new ConfEntry("windows-title", windows_title));
+    if (title.length() > 0) {
+        settings->addEntry(new ConfEntry("title", title));
     }
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -104,6 +104,8 @@ void LogstalgiaSettings::help(bool extended_help) {
     printf("  -o, --output-ppm-stream FILE   Write frames as PPM to a file ('-' for STDOUT)\n");
     printf("  -r, --output-framerate  FPS    Framerate of output (25,30,60)\n\n");
 
+    printf("  --windows-title TITLE      Title for Logstalgia window (default: empty)\n\n");
+
     printf("FILE should be a log file or '-' to read STDIN.\n\n");
 
     if(extended_help) {
@@ -203,6 +205,8 @@ LogstalgiaSettings::LogstalgiaSettings() {
     arg_types["display-fields"]     = "string";
     arg_types["address-separators"] = "string";
     arg_types["group-separators"]   = "string";
+
+    arg_types["windows-title"]   = "string";
 }
 
 void LogstalgiaSettings::setLogstalgiaDefaults() {
@@ -257,6 +261,8 @@ void LogstalgiaSettings::setLogstalgiaDefaults() {
     background_colour = vec3(0.0f, 0.0f, 0.0f);
 
     font_size = 14;
+
+    windows_title = "";
 
     groups.clear();
 }
@@ -693,6 +699,18 @@ void LogstalgiaSettings::importLogstalgiaSettings(ConfFile& conffile, ConfSectio
 
         std::cin.clear();
     }
+
+    if((entry = settings->getEntry("windows-title")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify windows title");
+
+        windows_title = entry->getString();
+
+        if(windows_title.empty() || windows_title.size() > 100) {
+            conffile.invalidValueException(entry);
+        }
+    }
+
 }
 
 void LogstalgiaSettings::exportLogstalgiaSettings(ConfFile& conf) {
@@ -851,6 +869,10 @@ void LogstalgiaSettings::exportLogstalgiaSettings(ConfFile& conf) {
     }
 
     settings->addEntry("path", path);
+
+    if (windows_title.length() > 0) {
+        settings->addEntry(new ConfEntry("windows-title", windows_title));
+    }
 }
 
 // SummarizerGroup

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,7 +18,7 @@
 #ifndef LOGSTALGIA_SETTINGS_H
 #define LOGSTALGIA_SETTINGS_H
 
-#define LOGSTALGIA_VERSION "1.0.8-wintitle"
+#define LOGSTALGIA_VERSION "1.0.8"
 
 #include "core/settings.h"
 
@@ -110,7 +110,7 @@ public:
 
     int font_size;
 
-    std::string windows_title;
+    std::string title;
 
     LogstalgiaSettings();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,7 +18,7 @@
 #ifndef LOGSTALGIA_SETTINGS_H
 #define LOGSTALGIA_SETTINGS_H
 
-#define LOGSTALGIA_VERSION "1.0.8"
+#define LOGSTALGIA_VERSION "1.0.8-wintitle"
 
 #include "core/settings.h"
 
@@ -109,6 +109,8 @@ public:
     std::string path_separators;
 
     int font_size;
+
+    std::string windows_title;
 
     LogstalgiaSettings();
 


### PR DESCRIPTION
Adds "windows title" in the top middle of the Logstalgia windows. By default the title is empty and thus not shown, but it can be set by command line parameter `--windows-title <title>`.