### PR TITLE
m4/ax_check_gl.m4 should probe with an OpenGL function

### DIFF
--- a/m4/ax_check_gl.m4
+++ b/m4/ax_check_gl.m4
@@ -89,7 +89,7 @@ m4_define([AX_CHECK_GL_GLX_PROGRAM],
 # else
 #   error no gl.h
 # endif]],
-                           [[glXQueryVersion(0, 0, 0)]])])
+                           [[glBegin(0)]])])
 
 AC_CACHE_CHECK([for OpenGL library], [ax_cv_check_gl_libgl],
 [ax_cv_check_gl_libgl=no


### PR DESCRIPTION
Using a GLX function results in an implicit function declaration, which some compilers reject, causing the check to fail incorrectly.

This has been fixed in upstream autoconf-archive as part of a rewrite.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
